### PR TITLE
Add GPU clock frequencies support

### DIFF
--- a/NvAPISample/Program.cs
+++ b/NvAPISample/Program.cs
@@ -60,6 +60,17 @@ namespace NvAPISample
                             "PhysicalGPU.GetPhysicalGPUs()", "Select a GPU to show thermal sensor values")
                 },
                 {
+                    "GPU Clock Frequencies", () =>
+                        ConsoleNavigation.PrintNavigation(
+                            PhysicalGPU.GetPhysicalGPUs()
+                                .ToDictionary(gpu => (object) gpu.ToString(), gpu => new Action(
+                                    () =>
+                                    {
+                                        ConsoleNavigation.PrintObject(gpu.ClockFrequencies, "gpu.ClockFrequencies");
+                                    })),
+                            "PhysicalGPU.GetPhysicalGPUs()", "Select a GPU to show thermal sensor values")
+                },
+                {
                     "GPU Dynamic Performance States", () =>
                         ConsoleNavigation.PrintNavigation(
                             PhysicalGPU.GetPhysicalGPUs()

--- a/NvAPIWrapper/GPU/PhysicalGPU.cs
+++ b/NvAPIWrapper/GPU/PhysicalGPU.cs
@@ -109,6 +109,11 @@ namespace NvAPIWrapper.GPU
             => GPUApi.GetDynamicPerformanceStatesInfoEx(Handle);
 
         /// <summary>
+        ///     Gets GPU clock frequencies
+        /// </summary>
+        public IClockFrequenciesInfo ClockFrequencies => GPUApi.GetAllClockFrequencies(Handle);
+
+        /// <summary>
         ///     Gets GPU full name
         /// </summary>
         public string FullName => GPUApi.GetFullName(Handle);

--- a/NvAPIWrapper/Native/Delegates/GPU.cs
+++ b/NvAPIWrapper/Native/Delegates/GPU.cs
@@ -103,6 +103,11 @@ namespace NvAPIWrapper.Native.Delegates
             [In] PhysicalGPUHandle physicalGpu,
             [In] [Accepts(typeof(DynamicPerformanceStatesInfo))] ValueTypeReference performanceStatesInfoEx);
 
+        [FunctionId(FunctionId.NvAPI_GPU_GetAllClockFrequencies)]
+        public delegate Status NvAPI_GPU_GetAllClockFrequencies(
+            [In] PhysicalGPUHandle physicalGpu, 
+            [In] [Accepts(typeof(ClockFrequenciesV3), typeof(ClockFrequenciesV2), typeof(ClockFrequenciesV1))] ValueTypeReference nvClocks);
+
         [FunctionId(FunctionId.NvAPI_GPU_GetEDID)]
         public delegate Status NvAPI_GPU_GetEDID(
             [In] PhysicalGPUHandle physicalGpu, [In] OutputId outputId,

--- a/NvAPIWrapper/Native/GPU/PublicClockId.cs
+++ b/NvAPIWrapper/Native/GPU/PublicClockId.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NvAPIWrapper.Native.GPU
+{
+    /// <summary>
+    ///     Clock id for determine right offset of clocks domain array
+    /// </summary>
+    public enum PublicClockId
+    {
+        /// <summary>
+        ///     Undefined id (value of NVAPI_MAX_GPU_PUBLIC_CLOCKS = 32)
+        /// </summary>
+        Undefined = 32,
+
+        /// <summary>
+        ///     Graphics engine clocks id
+        /// </summary>
+        Graphics = 0,
+
+        /// <summary>
+        ///     Memory engine clocks id
+        /// </summary>
+        Memory = 4,
+
+        /// <summary>
+        ///     Video processor clock id
+        /// </summary>
+        Processor = 7,
+
+        Video = 8
+    }
+}

--- a/NvAPIWrapper/Native/GPU/Structures/ClockDomainInfo.cs
+++ b/NvAPIWrapper/Native/GPU/Structures/ClockDomainInfo.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using NvAPIWrapper.Native.Helpers;
+
+namespace NvAPIWrapper.Native.GPU.Structures
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
+    public struct ClockDomainInfo
+    {
+        internal readonly uint _IsPresent;
+        internal readonly uint _Frequency;
+
+        public bool IsPresent => _IsPresent.GetBit(0);
+
+        public uint Frequency => _Frequency;
+
+        /// <inheritdoc />
+        public override string ToString() {
+            return IsPresent ? $"{_Frequency} kHz" : "Not Present";
+        }
+    }
+}

--- a/NvAPIWrapper/Native/GPU/Structures/ClockFrequenciesV1.cs
+++ b/NvAPIWrapper/Native/GPU/Structures/ClockFrequenciesV1.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using NvAPIWrapper.Native.Attributes;
+using NvAPIWrapper.Native.General.Structures;
+using NvAPIWrapper.Native.Interfaces;
+using NvAPIWrapper.Native.Interfaces.GPU;
+using static System.String;
+
+namespace NvAPIWrapper.Native.GPU.Structures
+{
+    /// <summary>
+    /// Holds information about all present gpu clock frequencies (in kHz)
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
+    [StructureVersion(1)]
+    public struct ClockFrequenciesV1 : IInitializable, IClockFrequenciesInfo
+    {
+        internal const int MaxClocksPerGpu = 32;
+
+        internal StructureVersion _Version;
+        internal readonly uint _Reserved;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = MaxClocksPerGpu)] internal 
+            ClockDomainInfo[] _Clocks;
+
+        public ClockDomainInfo ClockGraphics => _Clocks[(int)PublicClockId.Graphics];
+
+        public ClockDomainInfo ClockMemory => _Clocks[(int)PublicClockId.Memory];
+
+        public ClockDomainInfo ClockVideo => _Clocks[(int)PublicClockId.Video];
+
+        public ClockDomainInfo ClockProcessor => _Clocks[(int)PublicClockId.Processor];
+
+        public ClockDomainInfo[] Domain => _Clocks;
+
+        /// <inheritdoc />
+        public override string ToString() {
+            return "ClockFrequenciesV1: " + Join(", ", _Clocks.Select((x, index) => $"{index} = '{x}'").ToArray());
+        }
+    }
+}

--- a/NvAPIWrapper/Native/GPU/Structures/ClockFrequenciesV2.cs
+++ b/NvAPIWrapper/Native/GPU/Structures/ClockFrequenciesV2.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using NvAPIWrapper.Native.Attributes;
+using NvAPIWrapper.Native.General.Structures;
+using NvAPIWrapper.Native.Interfaces;
+using NvAPIWrapper.Native.Interfaces.GPU;
+using static System.String;
+
+namespace NvAPIWrapper.Native.GPU.Structures
+{
+    /// <summary>
+    /// Holds information about all present gpu clock frequencies (in kHz)
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
+    [StructureVersion(2)]
+    public struct ClockFrequenciesV2 : IInitializable, IClockFrequenciesInfo
+    {
+        internal const int MaxClocksPerGpu = 32;
+
+        internal StructureVersion _Version;
+        internal readonly uint _ClockTypeAndReserve;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = MaxClocksPerGpu)] internal 
+            ClockDomainInfo[] _Clocks;
+
+        public ClockDomainInfo[] Domain => _Clocks;
+
+        public ClockDomainInfo ClockGraphics => _Clocks[(int)PublicClockId.Graphics];
+
+        public ClockDomainInfo ClockMemory => _Clocks[(int)PublicClockId.Memory];
+
+        public ClockDomainInfo ClockVideo => _Clocks[(int)PublicClockId.Video];
+
+        public ClockDomainInfo ClockProcessor => _Clocks[(int)PublicClockId.Processor];
+
+        /// <inheritdoc />
+        public override string ToString() {
+            return "ClockFrequenciesV2: " + Join(", ", _Clocks.Select((x, index) => $"{index} = '{x}'").ToArray());
+        }
+    }
+}

--- a/NvAPIWrapper/Native/GPU/Structures/ClockFrequenciesV3.cs
+++ b/NvAPIWrapper/Native/GPU/Structures/ClockFrequenciesV3.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using NvAPIWrapper.Native.Attributes;
+using NvAPIWrapper.Native.General.Structures;
+using NvAPIWrapper.Native.Interfaces;
+using NvAPIWrapper.Native.Interfaces.GPU;
+using static System.String;
+
+namespace NvAPIWrapper.Native.GPU.Structures
+{
+    /// <summary>
+    /// Holds information about all present gpu clock frequencies (in kHz)
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
+    [StructureVersion(3)]
+    public struct ClockFrequenciesV3 : IInitializable, IClockFrequenciesInfo
+    {
+        internal const int MaxClocksPerGpu = 32;
+
+        internal StructureVersion _Version;
+        internal readonly uint _ClockTypeAndReserve;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = MaxClocksPerGpu)] internal
+            ClockDomainInfo[] _Clocks;
+
+        public ClockDomainInfo[] Domain => _Clocks;
+
+        public ClockDomainInfo ClockGraphics => _Clocks[(int)PublicClockId.Graphics];
+
+        public ClockDomainInfo ClockMemory => _Clocks[(int)PublicClockId.Memory];
+
+        public ClockDomainInfo ClockVideo => _Clocks[(int)PublicClockId.Video];
+
+        public ClockDomainInfo ClockProcessor => _Clocks[(int)PublicClockId.Processor];
+
+        /// <inheritdoc />
+        public override string ToString() {
+            return "ClockFrequenciesV3: " + Join(", ", _Clocks.Select((x, index) => $"{index} = '{x}'").ToArray());
+        }
+    }
+}

--- a/NvAPIWrapper/Native/Interfaces/GPU/IClockFrequenciesInfo.cs
+++ b/NvAPIWrapper/Native/Interfaces/GPU/IClockFrequenciesInfo.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using NvAPIWrapper.Native.GPU;
+using NvAPIWrapper.Native.GPU.Structures;
+
+namespace NvAPIWrapper.Native.Interfaces.GPU
+{
+    public interface IClockFrequenciesInfo
+    {
+        /// <summary>
+        ///     Representing all possible clocks in single domain array
+        /// </summary>
+        ClockDomainInfo[] Domain { get; }
+
+        /// <summary>
+        ///     Representing graphics engine clocks
+        /// </summary>
+        ClockDomainInfo ClockGraphics { get; }
+
+        /// <summary>
+        ///     Representing memory engine clocks
+        /// </summary>
+        ClockDomainInfo ClockMemory { get; }
+
+        ClockDomainInfo ClockVideo { get; }
+
+        ClockDomainInfo ClockProcessor { get; }
+    }
+}


### PR DESCRIPTION
Add `NvAPI_GPU_GetAllClockFrequencies` support (V1, V2, V3), would be nice to add this.
Also, I think need to add some more documentation about new methods, but don't know how to describe some of added enums (nvapi.h don't have any comments about this).