### PR TITLE
Fixes marshalling errors with EDID.CreateWithData().

### DIFF
--- a/NvAPIWrapper/Native/GPU/Structures/EDIDV1.cs
+++ b/NvAPIWrapper/Native/GPU/Structures/EDIDV1.cs
@@ -33,7 +33,7 @@ namespace NvAPIWrapper.Native.GPU.Structures
             }
 
             var edid = typeof(EDIDV1).Instantiate<EDIDV1>();
-            edid._Data = data;
+            Array.Copy(data, edid._Data, data.Length);
 
             return edid;
         }

--- a/NvAPIWrapper/Native/GPU/Structures/EDIDV2.cs
+++ b/NvAPIWrapper/Native/GPU/Structures/EDIDV2.cs
@@ -37,7 +37,7 @@ namespace NvAPIWrapper.Native.GPU.Structures
 
             var edid = typeof(EDIDV2).Instantiate<EDIDV2>();
             edid._TotalSize = (uint) totalSize;
-            edid._Data = data;
+            Array.Copy(data, 0, edid._Data, 0, totalSize);
 
             return edid;
         }

--- a/NvAPIWrapper/Native/GPU/Structures/EDIDV3.cs
+++ b/NvAPIWrapper/Native/GPU/Structures/EDIDV3.cs
@@ -50,7 +50,7 @@ namespace NvAPIWrapper.Native.GPU.Structures
             edid._Identification = id;
             edid._DataOffset = offset;
             edid._TotalSize = (uint) totalSize;
-            edid._Data = data;
+            Array.Copy(data, 0, edid._Data, offset, totalSize);
 
             return edid;
         }


### PR DESCRIPTION
`EDID*.CreateWithData()` would replace the `_Data` array with the passed `data` value, which would not necessarily have the correct size as specified in the `MarshalAs` attribute for `_Data`. That in turn would result in marshalling errors when using that values with `GPUApi.SetEDID()`.

Now we just copy `data` into `_Data` retaining the original size.